### PR TITLE
remove ALPHA = IN

### DIFF
--- a/src/zcl_datatable.clas.abap
+++ b/src/zcl_datatable.clas.abap
@@ -98,7 +98,7 @@ CLASS zcl_datatable IMPLEMENTATION.
       ENDIF.
       ASSIGN COMPONENT datatable_line->column OF STRUCTURE <line> TO <cell>.
       CHECK <cell> IS ASSIGNED.
-      <cell> = |{ datatable_line->value ALPHA = IN }|.
+      <cell> = datatable_line->value.
       UNASSIGN <cell>.
     ENDLOOP.
     APPEND <line> TO <table>.


### PR DESCRIPTION
if `ALPHA = IN` is applied to a string, it will never have any effect?

all unit tests pass in system after change,

and also outside system 🎉 

![image](https://github.com/dominikpanzer/cacamber-BDD-for-ABAP/assets/5888506/308ac3ce-663d-4ec7-af0f-4d2470ca9664)
